### PR TITLE
Require Composer Autoload

### DIFF
--- a/handler.php
+++ b/handler.php
@@ -1,6 +1,7 @@
 <?php
 // set up Symphony 
 define('DOCROOT', rtrim(dirname(__FILE__), '/') . '/../..');
+require_once(DOCROOT . '/vendor/autoload.php');
 require_once(DOCROOT . '/symphony/lib/boot/bundle.php');
 //require_once(CORE . '/class.administration.php');
 require_once(CORE . '/class.frontend.php');


### PR DESCRIPTION
This fix is necessary to work with Symphony 2.6.
Cheers.