### PR TITLE
Add note that Entries plugin requires 'index' Page

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -82,6 +82,8 @@ Incomplete documentation. Eventually similar documentation to Section Schemas ex
 
 The Entries plugin provides the same functionality of data sources (read entries) and events (create and update entries).
 
+Please note, this plugin assumes your Symphony installation has at least a Page assigned the type index.
+
 To **list entries** from a section:
 
 	/symphony/api/entries/:section_handle


### PR DESCRIPTION
After I couple of hours of testing, head-scratching, head-banging, I noticed the comment here https://github.com/symphonists/rest_api/blob/30ad34a934f79ab1a91628edd88d3291efb0e3f7/plugins/entries/rest.entries.php#L88

I was testing in a new installation without any pages yet, wondering why a 404 was being thrown, that wasn't an API formatted 404.